### PR TITLE
feat: 모든 Exception AOP 처리 #97

### DIFF
--- a/src/main/java/com/moayo/moayoeats/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/moayo/moayoeats/global/exception/GlobalExceptionHandler.java
@@ -22,9 +22,14 @@ public class GlobalExceptionHandler {
     public ApiResponse<List<String>> handleMethodArgumentNotValidException(
         BindingResult bindingResult) {
         List<String> errors = bindingResult.getFieldErrors().stream()
-            .map((FieldError fieldError) -> fieldError.getField() + fieldError.getDefaultMessage())
+            .map((FieldError fieldError) -> fieldError.getField() +" "+ fieldError.getDefaultMessage())
             .toList();
         return new ApiResponse<>(HttpStatus.BAD_REQUEST.value(), "입력값이 잘못되었습니다", errors);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ApiResponse<String> handleALLException(Exception ex){
+        return new ApiResponse<>(HttpStatus.BAD_REQUEST.value(), "에러가 발생했습니다", ex.getMessage());
     }
 
 }


### PR DESCRIPTION
## 개요
GlobalExceptionHandler 수정

## 작업사항

- 모든 에러들을 Global Exception Handler에서 처리함, 세부적으로 Handler가 구현된 Exception의 하위 클래스들 ex) GlobalException, MethodArgumentNotValidException 은 Global Exception Handler에 구현한 로직으로 동작함
- handleMethodArgumentNotValidException 의 field와 message사이에 공백 하나 넣음

## 변경 로직
- handleMethodArgumentNotValidException 의 field와 message사이에 공백 하나 넣음

## 관련 이슈
