### PR TITLE
feat: 알림 목록 조회 #61

### DIFF
--- a/src/main/java/com/moayo/moayoeats/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/moayo/moayoeats/domain/notification/controller/NotificationController.java
@@ -1,0 +1,31 @@
+package com.moayo.moayoeats.domain.notification.controller;
+
+import com.moayo.moayoeats.domain.notification.dto.response.*;
+import com.moayo.moayoeats.domain.notification.service.*;
+import com.moayo.moayoeats.global.dto.*;
+import com.moayo.moayoeats.global.security.*;
+import java.util.*;
+import lombok.*;
+import org.springframework.http.*;
+import org.springframework.security.core.annotation.*;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/notifications")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    //TODO: 알림 목록 조회
+    @GetMapping
+    public ApiResponse<List<NotificationsResponse>> getNotifications(
+        @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        List<NotificationsResponse> notificationsRes = notificationService.getNotifications(
+            userDetails.getUser());
+        return new ApiResponse<>(HttpStatus.OK.value(), "알림 목록을 불러왔습니다!", notificationsRes);
+    }
+
+    //TODO: 알림 전체 삭제
+}

--- a/src/main/java/com/moayo/moayoeats/domain/notification/dto/request/NotificationsRequest.java
+++ b/src/main/java/com/moayo/moayoeats/domain/notification/dto/request/NotificationsRequest.java
@@ -1,0 +1,5 @@
+package com.moayo.moayoeats.domain.notification.dto.request;
+
+public record NotificationsRequest(Long postId) {
+
+}

--- a/src/main/java/com/moayo/moayoeats/domain/notification/dto/response/NotificationsResponse.java
+++ b/src/main/java/com/moayo/moayoeats/domain/notification/dto/response/NotificationsResponse.java
@@ -1,0 +1,24 @@
+package com.moayo.moayoeats.domain.notification.dto.response;
+
+import com.moayo.moayoeats.domain.notification.entity.*;
+import com.moayo.moayoeats.domain.user.entity.*;
+import java.time.*;
+import lombok.*;
+
+@Builder
+public record NotificationsResponse(
+    User user,
+    NotificationType type,
+    String fieldContent,
+    LocalDateTime createdAt
+) {
+
+    public static NotificationsResponse formWith(Notification notification) {
+        return NotificationsResponse.builder()
+            .user(notification.getUser())
+            .type(notification.getFieldName())
+            .fieldContent(notification.getContent())
+            .createdAt(notification.getCreatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/moayo/moayoeats/domain/notification/entity/Notification.java
+++ b/src/main/java/com/moayo/moayoeats/domain/notification/entity/Notification.java
@@ -1,0 +1,37 @@
+package com.moayo.moayoeats.domain.notification.entity;
+
+import com.moayo.moayoeats.domain.user.entity.*;
+import com.moayo.moayoeats.global.entity.*;
+import jakarta.persistence.*;
+import java.time.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "tb_notification")
+public class Notification extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private NotificationType fieldName;
+    @Column(nullable = false)
+    private String content;
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Builder
+    public Notification(NotificationType notificationType, String content, LocalDateTime createdAt,
+        User user) {
+        this.fieldName = notificationType;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/moayo/moayoeats/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/moayo/moayoeats/domain/notification/entity/NotificationType.java
@@ -1,0 +1,20 @@
+package com.moayo.moayoeats.domain.notification.entity;
+
+import lombok.*;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationType {
+    //방장에게 Host
+    PARTICIPANT_JOIN_REQUEST("참가 요청 신청이 도착했습니다!"),
+    AMOUNT_COLLECTED("설정한 금액이 모두 모였습니다!"),
+
+    //참가자에게 Participant
+    PARTICIPANT_REJECTED("참가 요청이 거절 되었습니다!"),
+    PARTICIPANT_APPROVED("참가 요청이 승인 되었습니다!"),
+    MEETING_ACTIVATED("모임이 활성화 되었습니다!"),
+    MEETING_DELETED("모집글이 삭제 되었습니다!");
+
+    private final String word;
+
+}

--- a/src/main/java/com/moayo/moayoeats/domain/notification/event/Event.java
+++ b/src/main/java/com/moayo/moayoeats/domain/notification/event/Event.java
@@ -1,0 +1,21 @@
+package com.moayo.moayoeats.domain.notification.event;
+
+import com.moayo.moayoeats.domain.notification.entity.*;
+import com.moayo.moayoeats.domain.user.entity.*;
+import lombok.*;
+
+@Builder
+public record Event(
+
+    User user,
+
+    NotificationType notificationType
+) {
+
+    public static Event formWith(User user, NotificationType type) {
+        return Event.builder()
+            .user(user)
+            .notificationType(type)
+            .build();
+    }
+}

--- a/src/main/java/com/moayo/moayoeats/domain/notification/event/NotificationListener.java
+++ b/src/main/java/com/moayo/moayoeats/domain/notification/event/NotificationListener.java
@@ -1,0 +1,26 @@
+package com.moayo.moayoeats.domain.notification.event;
+
+import com.moayo.moayoeats.domain.notification.entity.*;
+import com.moayo.moayoeats.domain.notification.repository.*;
+import com.moayo.moayoeats.domain.user.entity.*;
+import lombok.*;
+import org.springframework.context.event.*;
+import org.springframework.stereotype.*;
+
+@RequiredArgsConstructor
+@Component
+public class NotificationListener {
+
+    private final NotificationRepository notificationRepository;
+
+    @EventListener
+    public void RequestNotify(User user, Event event) {
+        Notification newNotification = Notification.builder()
+            .user(user)
+            .notificationType(event.notificationType())
+            .content(event.notificationType().getWord()).build();
+        notificationRepository.save(newNotification);
+
+    }
+
+}

--- a/src/main/java/com/moayo/moayoeats/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/moayo/moayoeats/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,10 @@
+package com.moayo.moayoeats.domain.notification.repository;
+
+import com.moayo.moayoeats.domain.notification.entity.*;
+import java.util.*;
+import org.springframework.data.jpa.repository.*;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> findAllByUserId(Long id);
+}

--- a/src/main/java/com/moayo/moayoeats/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/moayo/moayoeats/domain/notification/service/NotificationService.java
@@ -1,0 +1,15 @@
+package com.moayo.moayoeats.domain.notification.service;
+
+import com.moayo.moayoeats.domain.notification.dto.response.*;
+import com.moayo.moayoeats.domain.user.entity.*;
+import java.util.*;
+
+public interface NotificationService {
+
+    /**
+     * @param user
+     * @return 해당 유저에 대한 알림들
+     */
+    List<NotificationsResponse> getNotifications(User user);
+
+}

--- a/src/main/java/com/moayo/moayoeats/domain/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/moayo/moayoeats/domain/notification/service/impl/NotificationServiceImpl.java
@@ -1,0 +1,41 @@
+package com.moayo.moayoeats.domain.notification.service.impl;
+
+import com.moayo.moayoeats.domain.notification.dto.response.*;
+import com.moayo.moayoeats.domain.notification.entity.*;
+import com.moayo.moayoeats.domain.notification.repository.*;
+import com.moayo.moayoeats.domain.notification.service.*;
+import com.moayo.moayoeats.domain.user.entity.*;
+import com.moayo.moayoeats.domain.user.exception.*;
+import com.moayo.moayoeats.domain.user.repository.*;
+import com.moayo.moayoeats.global.exception.*;
+import java.util.*;
+import lombok.*;
+import org.springframework.stereotype.*;
+
+@RequiredArgsConstructor
+@Service
+public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
+
+    //TODO: 알림 목록 조회
+    public List<NotificationsResponse> getNotifications(User user) {
+
+        User targetUser = userRepository.findByEmail(user.getEmail())
+            .orElseThrow(() -> new GlobalException(
+                UserErrorCode.NOT_EXIST_USER));
+
+        List<Notification> notifications = notificationRepository.findAllByUserId(
+            targetUser.getId());
+        List<NotificationsResponse> NotificationsRes = new ArrayList<>();
+        notifications.sort(((o1, o2) -> o2.getCreatedAt()
+            .compareTo(o1.getCreatedAt())));
+        for (Notification notification : notifications) {
+            NotificationsRes.add(NotificationsResponse.formWith(notification));
+        }
+
+        return NotificationsRes;
+    }
+
+}


### PR DESCRIPTION
## 개요
- 알림 기능을 위한 기초작업
- 알림 목록 조회 기능 구현
- 'Spring Event' 사용해 구현해갈 예정
- Event가 발생 할 Service단 내 메서드 말단에 추가 로직 구현 필요(예정)

## 작업 사항
- 알림 목록 조회 API구현
- event 패키지에 publish 할 정보를 받아 알림을 만들고 저장하는 Listener 클래스 구현

## 특이사항
- 현재 publish 코드가 없어 실행(run)이 안되는 걸로 파악.
=> domain.notification.event- NotificationListener 클래스 주석 처리하면 실행 됨.(주석처리하고 올릴걸 깜빡함..)

## 관련 이슈
close #61 알림 전체 조회
알림 작업을 위한 Spring Event 관련 작업 #136
