### PR TITLE
Feat/review and score refactor

### DIFF
--- a/src/main/java/com/moayo/moayoeats/backend/domain/review/dto/request/ReviewRequest.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/review/dto/request/ReviewRequest.java
@@ -1,6 +1,6 @@
 package com.moayo.moayoeats.backend.domain.review.dto.request;
 
-import com.moayo.moayoeats.backend.domain.review.entity.ScoreEnum;
+import com.moayo.moayoeats.backend.domain.score.entity.ScoreEnum;
 
 public record ReviewRequest(
     Long orderId,

--- a/src/main/java/com/moayo/moayoeats/backend/domain/review/entity/Review.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/review/entity/Review.java
@@ -1,9 +1,10 @@
 package com.moayo.moayoeats.backend.domain.review.entity;
 
 import com.moayo.moayoeats.backend.domain.user.entity.User;
-import com.moayo.moayoeats.backend.global.entity.BaseTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -12,6 +13,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,7 +21,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "tb_review")
-public class Review extends BaseTime {
+public class Review {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,84 +32,21 @@ public class Review extends BaseTime {
     private User user;
 
     @Column
-    private Integer score;
+    @Enumerated(EnumType.STRING)
+    private ReviewEnum content;
 
     @Column
     private Integer count;
 
-    @Column
-    private Integer goodmanner;
-
-    @Column
-    private Integer goodtime;
-
-    @Column
-    private Integer goodcomm;
-
-    @Column
-    private Integer badtime;
-
-    @Column
-    private Integer noshow;
-
-    @Column
-    private Integer nomoney;
-
-    @Column
-    private Integer badcomm;
-
-    @Column
-    private Integer badmanner;
-
-    public Review(User user) {
+    @Builder
+    public Review(User user, ReviewEnum content) {
         this.user = user;
-        this.score = 0;
+        this.content = content;
         this.count = 0;
-        this.goodmanner = 0;
-        this.goodtime = 0;
-        this.goodcomm = 0;
-        this.badtime = 0;
-        this.noshow = 0;
-        this.nomoney = 0;
-        this.badcomm = 0;
-        this.badmanner = 0;
     }
 
-    public void increaseScoreAndCount(ScoreEnum scoreEnum) {
-        this.score += scoreEnum.getScore();
-        this.count += 1;
-    }
-
-    public void increaseGoodmanner() {
-        this.goodmanner++;
-    }
-
-    public void increaseGoodtime() {
-        this.goodtime++;
-    }
-
-    public void increaseGoodcomm() {
-        this.goodcomm++;
-    }
-
-    public void increaseBadtime() {
-        this.badtime++;
-    }
-
-    public void increaseNoshow() {
-        this.noshow++;
-    }
-
-    public void increaseNomoney() {
-        this.nomoney++;
-    }
-
-    public void increaseBadcomm() {
-        this.badcomm++;
-    }
-
-    public void increaseBadmanner() {
-        this.badmanner++;
+    public void increaseCount(){
+        this.count++;
     }
 
 }

--- a/src/main/java/com/moayo/moayoeats/backend/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/review/repository/ReviewRepository.java
@@ -2,9 +2,9 @@ package com.moayo.moayoeats.backend.domain.review.repository;
 
 import com.moayo.moayoeats.backend.domain.review.entity.Review;
 import com.moayo.moayoeats.backend.domain.user.entity.User;
-import java.util.Optional;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review,Long> {
-    Optional<Review> findByUser(User user);
+    List<Review> findAllByUser(User user);
 }

--- a/src/main/java/com/moayo/moayoeats/backend/domain/review/service/impl/ReviewServiceImpl.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/review/service/impl/ReviewServiceImpl.java
@@ -7,12 +7,17 @@ import com.moayo.moayoeats.backend.domain.order.exception.OrderErrorCode;
 import com.moayo.moayoeats.backend.domain.order.repository.OrderRepository;
 import com.moayo.moayoeats.backend.domain.review.dto.request.ReviewRequest;
 import com.moayo.moayoeats.backend.domain.review.entity.Review;
+import com.moayo.moayoeats.backend.domain.review.entity.ReviewEnum;
 import com.moayo.moayoeats.backend.domain.review.repository.ReviewRepository;
 import com.moayo.moayoeats.backend.domain.review.service.ReviewService;
+import com.moayo.moayoeats.backend.domain.score.entity.Score;
+import com.moayo.moayoeats.backend.domain.score.entity.ScoreEnum;
+import com.moayo.moayoeats.backend.domain.score.repository.ScoreRepository;
 import com.moayo.moayoeats.backend.domain.user.entity.User;
 import com.moayo.moayoeats.backend.domain.user.exception.UserErrorCode;
 import com.moayo.moayoeats.backend.domain.user.repository.UserRepository;
 import com.moayo.moayoeats.backend.global.exception.GlobalException;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,6 +29,7 @@ public class ReviewServiceImpl implements ReviewService {
     private final ReviewRepository reviewRepository;
     private final OrderRepository orderRepository;
     private final UserRepository userRepository;
+    private final ScoreRepository scoreRepository;
 
     @Override
     public List<OrderResponse> getOrders(User user) {
@@ -40,14 +46,14 @@ public class ReviewServiceImpl implements ReviewService {
     @Override
     public void review(ReviewRequest reviewReq, User user) {
         Order order = findOrderById(reviewReq.orderId());
+        //check if the receiver exists, to clarify that the review hasn't been made, not because the user doesn't exist
         if(!order.getUser().getId().equals(user.getId())){
             throw new GlobalException(OrderErrorCode.FORBIDDEN_ACCESS);
         }
         User receiver = order.getReceiver();
         checkIfUserExists(receiver.getId());
-        Review review = findReviewByUser(receiver);
-        updateReview(review, reviewReq);
-        reviewRepository.save(review);
+        updateScore(reviewReq.score(),receiver);
+        updateReview(reviewReq, receiver);
         orderRepository.delete(order);
     }
 
@@ -62,42 +68,73 @@ public class ReviewServiceImpl implements ReviewService {
         }
     }
 
-    private Review findReviewByUser(User user) {
+    private void updateScore(ScoreEnum scoreEnum, User user){
+        Score score = findScoreByUser(user);
+        score.update(scoreEnum);
+        scoreRepository.save(score);
+    }
+
+    private Score findScoreByUser(User user){
+        return scoreRepository.findByUser(user).orElse(new Score(user));
+    }
+
+    private Review findReviewByContent(List<Review> reviews, ReviewEnum content, User user) {
         //get Review when exists, make a new one when not
-        return reviewRepository.findByUser(user).orElse(makeReview(user));
+        for(Review review : reviews){
+            if(review.getContent().equals(content)){
+                reviews.remove(review);
+                return review;
+            }
+        }
+        return new Review(user,content);
     }
 
-    private Review makeReview(User user) {
-        return new Review(user);
-    }
+    private void updateReview(ReviewRequest reviewReq, User receiver) {
 
-    private void updateReview(Review review, ReviewRequest reviewReq) {
-        review.increaseScoreAndCount(reviewReq.score());
+        List<Review> reviews = reviewRepository.findAllByUser(receiver);
+        List<Review> updated = new ArrayList<>();
 
         if (reviewReq.goodmanner()) {
-            review.increaseGoodmanner();
+            Review review = findReviewByContent(reviews,ReviewEnum.GOODMANNER,receiver);
+            review.increaseCount();
+            updated.add(review);
         }
         if (reviewReq.goodcomm()) {
-            review.increaseGoodcomm();
+            Review review = findReviewByContent(reviews,ReviewEnum.GOODCOMM,receiver);
+            review.increaseCount();
+            updated.add(review);
         }
         if (reviewReq.goodtime()) {
-            review.increaseGoodtime();
+            Review review = findReviewByContent(reviews,ReviewEnum.GOODTIME,receiver);
+            review.increaseCount();
+            updated.add(review);
         }
         if (reviewReq.badtime()) {
-            review.increaseBadtime();
+            Review review = findReviewByContent(reviews,ReviewEnum.BADTIME,receiver);
+            review.increaseCount();
+            updated.add(review);
         }
         if (reviewReq.noshow()) {
-            review.increaseNoshow();
+            Review review = findReviewByContent(reviews,ReviewEnum.NOSHOW,receiver);
+            review.increaseCount();
+            updated.add(review);
         }
         if (reviewReq.nomoney()) {
-            review.increaseNomoney();
+            Review review = findReviewByContent(reviews,ReviewEnum.NOMONEY,receiver);
+            review.increaseCount();
+            updated.add(review);
         }
         if (reviewReq.badcomm()) {
-            review.increaseBadcomm();
+            Review review = findReviewByContent(reviews,ReviewEnum.BADCOMM,receiver);
+            review.increaseCount();
+            updated.add(review);
         }
         if (reviewReq.badmanner()) {
-            review.increaseBadmanner();
+            Review review = findReviewByContent(reviews,ReviewEnum.BADMANNER,receiver);
+            review.increaseCount();
+            updated.add(review);
         }
+        reviewRepository.saveAll(updated);
     }
 
 }

--- a/src/main/java/com/moayo/moayoeats/backend/domain/score/entity/Score.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/score/entity/Score.java
@@ -1,0 +1,48 @@
+package com.moayo.moayoeats.backend.domain.score.entity;
+
+import com.moayo.moayoeats.backend.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "tb_score")
+public class Score {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "user_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @Column
+    private Integer total;
+
+    @Column
+    private Integer count;
+
+    public Score(User user) {
+        this.user = user;
+        this.total = 0;
+        this.count = 0;
+    }
+
+    public void update(ScoreEnum score){
+        this.total += score.getScore();
+        this.count++;
+    }
+
+}

--- a/src/main/java/com/moayo/moayoeats/backend/domain/score/entity/ScoreEnum.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/score/entity/ScoreEnum.java
@@ -1,4 +1,4 @@
-package com.moayo.moayoeats.backend.domain.review.entity;
+package com.moayo.moayoeats.backend.domain.score.entity;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/moayo/moayoeats/backend/domain/score/repository/ScoreRepository.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/score/repository/ScoreRepository.java
@@ -1,0 +1,12 @@
+package com.moayo.moayoeats.backend.domain.score.repository;
+
+import com.moayo.moayoeats.backend.domain.score.entity.Score;
+import com.moayo.moayoeats.backend.domain.user.entity.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScoreRepository extends JpaRepository<Score,Long> {
+
+    Optional<Score> findByUser(User user);
+
+}

--- a/src/main/java/com/moayo/moayoeats/backend/domain/user/entity/User.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/user/entity/User.java
@@ -1,11 +1,16 @@
 package com.moayo.moayoeats.backend.domain.user.entity;
 
+import com.moayo.moayoeats.backend.domain.review.entity.Review;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,6 +34,9 @@ public class User {
 
     @Column(nullable = false)
     private String nickname;
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    List<Review> reviews;
 
     @Builder
     public User(String email, String password, String nickname) {


### PR DESCRIPTION
## 개요
Review 관련 리팩토링

## 작업 사항
- Review Entity 리팩토링
- ReviewRepository에 findAllByUser 정의
- ScoreEnum Score 도메인으로 이동
- ReviewServiceImpl 리팩토링
- Score Entity 생성
- Score Repository 생성
- User Entity에 Review와 양방향 관계 설정
## 변경 로직
Review Entity에 boolean으로 있던 것 그냥 Review Entity 에는 ReviewEnum과 Count만 가지고 Review가 ReviewEnum마다 생기도록 변경함
Score Enitty 따로 뺌

## 관련 이슈
- #30
- close #270
