### PR TITLE
Feat/delete offers when close

### DIFF
--- a/src/main/java/com/moayo/moayoeats/backend/domain/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/post/service/impl/PostServiceImpl.java
@@ -7,6 +7,7 @@ import com.moayo.moayoeats.backend.domain.menu.entity.Menu;
 import com.moayo.moayoeats.backend.domain.menu.repository.MenuRepository;
 import com.moayo.moayoeats.backend.domain.notification.entity.NotificationType;
 import com.moayo.moayoeats.backend.domain.notification.event.Event;
+import com.moayo.moayoeats.backend.domain.offer.repository.OfferRepository;
 import com.moayo.moayoeats.backend.domain.order.entity.Order;
 import com.moayo.moayoeats.backend.domain.order.repository.OrderRepository;
 import com.moayo.moayoeats.backend.domain.post.dto.request.PostCategoryRequest;
@@ -47,6 +48,7 @@ public class PostServiceImpl implements PostService {
     private final ApplicationEventPublisher publisher;
     private final UserRepository userRepository;//Test
     private final ChatRoomService chatRoomService;
+    private final OfferRepository offerRepository;
 
 
     @Override
@@ -185,6 +187,9 @@ public class PostServiceImpl implements PostService {
                 menuRepository.delete(menu);
             }
         }
+
+        //delete all offers to prevent approving offers after the post is closed, and reduce database searching time
+        offerRepository.deleteAll(offerRepository.findAllByPostId(post.getId()));
 
         //참가자들에게 알림
         userPostRepository.findAllByPostAndRoleEquals(post, UserPostRole.PARTICIPANT)

--- a/src/main/java/com/moayo/moayoeats/backend/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/moayo/moayoeats/backend/global/config/WebSecurityConfig.java
@@ -1,7 +1,7 @@
 package com.moayo.moayoeats.backend.global.config;
 
 
-import com.moayo.moayoeats.backend.global.security.jwt.JwtUtil;
+import com.moayo.moayoeats.backend.global.jwt.JwtUtil;
 import com.moayo.moayoeats.backend.global.security.JwtAuthorizationFilter;
 import com.moayo.moayoeats.backend.global.security.UserDetailsServiceImpl;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
## 개요
모집마감 후에는 offer가 approve되면 안 됨, 추후 offer쓸 일이 없으므로 다른 offer를 검색할때 db조회도 줄이기 위해 모집마감시 그냥 해당 post의 모든 offer 삭제함

## 작업 사항
- #304

## 변경 로직
PostService의 모집마감 closeApplication 메서드에 offer삭제하는 부분 추가

## 관련 이슈
- #170
- #32
- close #304
