### PR TITLE
Feat/not delete menus when delete post

### DIFF
--- a/src/main/java/com/moayo/moayoeats/backend/domain/menu/entity/Menu.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/menu/entity/Menu.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.transaction.Transactional;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -58,7 +59,6 @@ public class Menu {
 
     public Menu receive(Order order){
         this.order = order;
-        this.post.dismissMenu(this);
         this.post = null;
         return this;
     }

--- a/src/main/java/com/moayo/moayoeats/backend/domain/post/entity/Post.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/post/entity/Post.java
@@ -88,17 +88,16 @@ public class Post {
         this.longitude = longitude;
     }
 
-    @Transactional
-    public void dismissMenu(Menu menu) {
-        this.menus.remove(menu);
-    }
-
     public void closeApplication() {
         this.postStatus = PostStatusEnum.CLOSED;
     }
 
     public void completeOrder() {
         this.postStatus = PostStatusEnum.ORDERED;
+    }
+
+    public void allReceived(){
+        this.postStatus = PostStatusEnum.RECEIVED;
     }
 
     public void changeAmountGoalStatus() {


### PR DESCRIPTION
## 개요
수령완료시 글 바로 삭제하는 대신 Received로 바꾸고 추후 스케쥴러가 삭제하게 함

## 작업 사항
- #310
- #311
 - #312

## 변경 로직
- Menu의 post와 연관관계 삭제하는 메서드에서 Post의 dissmissPost 메서드 삭제
- Post에서 dismissPost 메서드 삭제
- Post에 RECEIVED로 상태변경하는 메서드 구현
- PostService의 수령완료 메서드 리팩토링함

## 관련 이슈
- #177 
- #32
- close #310
- close #311
 - close #312
