### PR TITLE
fix: 중복되는 url path 수정

### DIFF
--- a/src/main/java/com/moayo/moayoeats/backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/post/controller/PostController.java
@@ -53,7 +53,7 @@ public class PostController {
     }
 
     // 모든 글 조회하기
-    @GetMapping("/posts/{page}")
+    @GetMapping("/posts/page/{page}")
     public ApiResponse<List<BriefPostResponse>> getPosts(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @PathVariable(name = "page") int page


### PR DESCRIPTION
## 개요
중복되는 url path 수정

## 작업 사항
Controller에 argument 형식이 같은 method가 두개 있어서 둘 중 하나 path 수정함
## 변경 로직
// 모든 글 조회하기
    @GetMapping("/posts/{page}")
->
// 모든 글 조회하기
    @GetMapping("/posts/page/{page}")
## 관련 이슈
