### PR TITLE
Feat/sorting by distance and category

### DIFF
--- a/src/main/java/com/moayo/moayoeats/backend/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/post/repository/PostCustomRepository.java
@@ -1,5 +1,6 @@
 package com.moayo.moayoeats.backend.domain.post.repository;
 
+import com.moayo.moayoeats.backend.domain.post.entity.CategoryEnum;
 import com.moayo.moayoeats.backend.domain.post.entity.Post;
 import com.moayo.moayoeats.backend.domain.user.entity.User;
 import java.util.List;
@@ -7,5 +8,6 @@ import java.util.List;
 public interface PostCustomRepository {
 
     List<Post> getPostsByDistance(int page,User user);
+    List<Post> getPostsByDistanceAndCategory(int page, User user, CategoryEnum category);
 
 }

--- a/src/main/java/com/moayo/moayoeats/backend/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/post/repository/PostCustomRepositoryImpl.java
@@ -21,6 +21,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 
         QPost post = QPost.post;
         int pagesize = 5;
+        int offset = page*pagesize;
 
         QueryResults<Post> results = jpaQueryFactory
             .selectFrom(post)
@@ -29,7 +30,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .add((post.longitude.subtract(user.getLongitude())).multiply(
                     (post.longitude.subtract(user.getLongitude())))))
                 .asc())
-            .offset(page)
+            .offset(offset)
             .limit(pagesize)
             .fetchResults();
 
@@ -42,6 +43,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 
         QPost post = QPost.post;
         int pagesize = 5;
+        int offset = page*pagesize;
 
         QueryResults<Post> results = jpaQueryFactory
             .selectFrom(post)
@@ -51,7 +53,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .add((post.longitude.subtract(user.getLongitude())).multiply(
                     (post.longitude.subtract(user.getLongitude())))))
                 .asc())
-            .offset(page*pagesize)
+            .offset(offset)
             .limit(pagesize)
             .fetchResults();
 

--- a/src/main/java/com/moayo/moayoeats/backend/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/post/repository/PostCustomRepositoryImpl.java
@@ -1,7 +1,6 @@
 package com.moayo.moayoeats.backend.domain.post.repository;
 
-import static com.querydsl.core.types.dsl.MathExpressions.power;
-
+import com.moayo.moayoeats.backend.domain.post.entity.CategoryEnum;
 import com.moayo.moayoeats.backend.domain.post.entity.Post;
 import com.moayo.moayoeats.backend.domain.post.entity.QPost;
 import com.moayo.moayoeats.backend.domain.user.entity.User;
@@ -9,8 +8,6 @@ import com.querydsl.core.QueryResults;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
@@ -20,19 +17,42 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<Post> getPostsByDistance(int page, User viewer) {
+    public List<Post> getPostsByDistance(int page, User user) {
 
         QPost post = QPost.post;
-
-        Pageable pageable = PageRequest.of(page, 5);
+        int pagesize = 5;
 
         QueryResults<Post> results = jpaQueryFactory
             .selectFrom(post)
-            .orderBy(((post.latitude.subtract(viewer.getLatitude())).multiply((post.latitude.subtract(viewer.getLatitude())))
-                .add((post.longitude.subtract(viewer.getLongitude())).multiply((post.longitude.subtract(viewer.getLongitude())))))
+            .orderBy(((post.latitude.subtract(user.getLatitude())).multiply(
+                    (post.latitude.subtract(user.getLatitude())))
+                .add((post.longitude.subtract(user.getLongitude())).multiply(
+                    (post.longitude.subtract(user.getLongitude())))))
                 .asc())
-            .offset(pageable.getOffset())
-            .limit(pageable.getPageSize())
+            .offset(page)
+            .limit(pagesize)
+            .fetchResults();
+
+        List<Post> closestPosts = results.getResults();
+        return closestPosts;
+    }
+
+    @Override
+    public List<Post> getPostsByDistanceAndCategory(int page, User user, CategoryEnum category) {
+
+        QPost post = QPost.post;
+        int pagesize = 5;
+
+        QueryResults<Post> results = jpaQueryFactory
+            .selectFrom(post)
+            .where(post.category.eq(category))
+            .orderBy(((post.latitude.subtract(user.getLatitude())).multiply(
+                    (post.latitude.subtract(user.getLatitude())))
+                .add((post.longitude.subtract(user.getLongitude())).multiply(
+                    (post.longitude.subtract(user.getLongitude())))))
+                .asc())
+            .offset(page*pagesize)
+            .limit(pagesize)
             .fetchResults();
 
         List<Post> closestPosts = results.getResults();

--- a/src/main/java/com/moayo/moayoeats/backend/domain/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/post/service/impl/PostServiceImpl.java
@@ -54,7 +54,8 @@ public class PostServiceImpl implements PostService {
     @Override
     public void createPost(PostRequest postReq, User user) {
         //set deadline to hours and mins after now
-        LocalDateTime deadline = LocalDateTime.now().plusMinutes(getIntFromString(postReq.deadlineMins()))
+        LocalDateTime deadline = LocalDateTime.now()
+            .plusMinutes(getIntFromString(postReq.deadlineMins()))
             .plusHours(getIntFromString(postReq.deadlineHours()));
 
         //get latitude and longitude from the coordinate
@@ -96,14 +97,7 @@ public class PostServiceImpl implements PostService {
 
     @Override
     public List<BriefPostResponse> getPosts(int page, User user) {
-        List<Post> posts;
-
-        if(user.getLatitude()==null||user.getLongitude()==null){
-            posts = findPage(page);
-        }else{
-            posts = postCustomRepository.getPostsByDistance(page,user);
-        }
-        return postsToBriefResponses(posts);
+        return getAllPosts(page, user);
     }
 
     @Override
@@ -166,13 +160,11 @@ public class PostServiceImpl implements PostService {
     public List<BriefPostResponse> getPostsByCategory(int page, String category, User user) {
         List<Post> posts;
         CategoryEnum categoryEnum = CategoryEnum.valueOf(category);
+
         if (category.equals(CategoryEnum.ALL.toString())) {
-            posts = findPage(page);
+            return getAllPosts(page, user);
         } else {
-            Pageable pageWithTenPosts = PageRequest.of(page, 10,
-                Sort.by("modifiedAt").descending());
-            posts = postRepository.findAllByCategoryEquals(pageWithTenPosts, categoryEnum)
-                .getContent();
+            posts = postCustomRepository.getPostsByDistanceAndCategory(page,user,categoryEnum);
         }
         return postsToBriefResponses(posts);
     }
@@ -283,7 +275,7 @@ public class PostServiceImpl implements PostService {
         Post post = getPostById(postIdReq.postId());
         UserPost userPost = getUserPostIfParticipant(user, post);
         checkIfOrdered(post.getPostStatus());
-        deleteParticipant(userPost,user,post);
+        deleteParticipant(userPost, user, post);
 
         List<UserPost> userposts = getUserPostsByPost(post);
         int sumPrice = getSumPrice(userposts, post);
@@ -318,7 +310,6 @@ public class PostServiceImpl implements PostService {
         if (userPosts.size() <= 2) {
             post.allReceived();
             relateOrderWithMenus(host, post, hostOrder);
-            return;
         }
     }
 
@@ -483,24 +474,35 @@ public class PostServiceImpl implements PostService {
         return address.split(",");
     }
 
-    private void checkIfOrdered(PostStatusEnum status){
+    private void checkIfOrdered(PostStatusEnum status) {
         if (status == PostStatusEnum.ORDERED
             || status == PostStatusEnum.RECEIVED) {
             throw new GlobalException(PostErrorCode.CANNOT_AFTER_ORDERED);
         }
     }
 
-    private void deleteParticipant(UserPost userPost, User user, Post post){
+    private void deleteParticipant(UserPost userPost, User user, Post post) {
         menuRepository.deleteAll(getUserMenus(user, post));
         userPostRepository.delete(userPost);
     }
 
-    private int getIntFromString(String s){
-        int i=0;
-        if(!s.equals("")){
+    private int getIntFromString(String s) {
+        int i = 0;
+        if (!s.equals("")) {
             i = Integer.parseInt(s);
         }
         return i;
+    }
+
+    private List<BriefPostResponse> getAllPosts(int page, User user) {
+        List<Post> posts;
+
+        if (user.getLatitude() == null || user.getLongitude() == null) {
+            posts = findPage(page);
+        } else {
+            posts = postCustomRepository.getPostsByDistance(page, user);
+        }
+        return postsToBriefResponses(posts);
     }
 
     @Scheduled(fixedRate = 60000)//executed every 1 min


### PR DESCRIPTION
## 개요
User의 주소와 가까운 순으로 페이지별 조회하게 refactoring 
## 작업 사항
PostCustomRepository에 유저 주소와 가까운 순으로 정렬하게 QueryMethod 구현
 PostService의 카테고리별 조회 메서드를 유저 주소와 가까운 순으로 정렬하게 하는 메서드 이용하게 변경

## 변경 로직
 PostCustomRepository의 getPostsByDistance의 offset값 수정함

## 관련 이슈
- #32 
- #88
- close #395