### PR TITLE
Feat/add category cafe

### DIFF
--- a/src/main/java/com/moayo/moayoeats/backend/domain/post/dto/request/PostRequest.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/post/dto/request/PostRequest.java
@@ -1,6 +1,7 @@
 package com.moayo.moayoeats.backend.domain.post.dto.request;
 
 import com.moayo.moayoeats.backend.domain.post.entity.CategoryEnum;
+import com.moayo.moayoeats.backend.domain.post.exception.validator.Category;
 import com.moayo.moayoeats.backend.domain.post.exception.validator.Hours;
 import com.moayo.moayoeats.backend.domain.post.exception.validator.Minutes;
 import com.moayo.moayoeats.backend.domain.post.exception.validator.Money;
@@ -24,7 +25,9 @@ public record PostRequest(
 
     @Hours
     String deadlineHours,
-    CategoryEnum category
+
+    @Category
+    String category
 
 ) {
 

--- a/src/main/java/com/moayo/moayoeats/backend/domain/post/entity/CategoryEnum.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/post/entity/CategoryEnum.java
@@ -17,6 +17,7 @@ public enum CategoryEnum {
     ASIAN,
     JAPANESE,
     CHINESE,
-    LUNCHBOX;
+    LUNCHBOX,
+    CAFE;
 
 }

--- a/src/main/java/com/moayo/moayoeats/backend/domain/post/entity/CategoryEnum.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/post/entity/CategoryEnum.java
@@ -17,7 +17,6 @@ public enum CategoryEnum {
     ASIAN,
     JAPANESE,
     CHINESE,
-    LUNCHBOX,
-    CAFE;
+    LUNCHBOX
 
 }

--- a/src/main/java/com/moayo/moayoeats/backend/domain/post/entity/Post.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/post/entity/Post.java
@@ -54,6 +54,9 @@ public class Post extends BaseTime {
     private CategoryEnum category;
 
     @Column
+    private String cuisine;
+
+    @Column
     private Long sumPrice;
 
     @Column
@@ -72,7 +75,7 @@ public class Post extends BaseTime {
     @Builder
     public Post(String store, Integer minPrice, Integer deliveryCost,
         CategoryEnum category, LocalDateTime deadline, PostStatusEnum postStatus, Double latitude,
-        Double longitude) {
+        Double longitude, String cuisine) {
         this.store = store;
         this.minPrice = minPrice;
         this.amountIsSatisfied = false;
@@ -82,6 +85,7 @@ public class Post extends BaseTime {
         this.postStatus = postStatus;
         this.latitude = latitude;
         this.longitude = longitude;
+        this.cuisine = cuisine;
     }
 
     public void closeApplication() {

--- a/src/main/java/com/moayo/moayoeats/backend/domain/post/exception/validator/CategoryValidator.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/post/exception/validator/CategoryValidator.java
@@ -24,7 +24,7 @@ public class CategoryValidator implements ConstraintValidator<Category, String> 
             ||categoryEnum.equals(CategoryEnum.PIZZA.toString())
             ||categoryEnum.equals(CategoryEnum.SNACK.toString())
             ||categoryEnum.equals(CategoryEnum.WESTERN.toString())
-            ||categoryEnum.equals(CategoryEnum.CAFE.toString())
+            ||categoryEnum.equals("CAFE")
             ;
     }
 

--- a/src/main/java/com/moayo/moayoeats/backend/domain/post/exception/validator/CategoryValidator.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/post/exception/validator/CategoryValidator.java
@@ -24,6 +24,7 @@ public class CategoryValidator implements ConstraintValidator<Category, String> 
             ||categoryEnum.equals(CategoryEnum.PIZZA.toString())
             ||categoryEnum.equals(CategoryEnum.SNACK.toString())
             ||categoryEnum.equals(CategoryEnum.WESTERN.toString())
+            ||categoryEnum.equals(CategoryEnum.CAFE.toString())
             ;
     }
 

--- a/src/main/java/com/moayo/moayoeats/backend/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/post/repository/PostCustomRepository.java
@@ -22,4 +22,6 @@ public interface PostCustomRepository {
 
     List<Post> getPostsByCuisine(int page, User user, String cuisine);
 
+    List<Post> getPostsByStatusAndCuisine(int page, PostStatusEnum statusEnum, String cuisine, User user);
+
 }

--- a/src/main/java/com/moayo/moayoeats/backend/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/post/repository/PostCustomRepository.java
@@ -11,6 +11,7 @@ public interface PostCustomRepository {
     List<Post> getPostsByDistance(int page,User user);
 
     List<Post> getPostsByStatusOrderByDistance(int page, PostStatusEnum status, User user);
+
     List<Post> getPostsByDistanceAndCategory(int page, User user, CategoryEnum category);
 
     List<Post> getPostsByDistanceAndKeyword(int page, User user, String keyword);
@@ -18,5 +19,7 @@ public interface PostCustomRepository {
     List<Post> getPostsByStatusAndCategoryOrderByDistance(int page, PostStatusEnum status, CategoryEnum category ,User user);
 
     List<Post> getPostsByStatusAndKeywordOrderByDistance(int page, PostStatusEnum statusEnum, String keyword , User user);
+
+    List<Post> getPostsByCuisine(int page, User user, String cuisine);
 
 }

--- a/src/main/java/com/moayo/moayoeats/backend/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/post/repository/PostCustomRepositoryImpl.java
@@ -51,9 +51,9 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
     public List<Post> getPostsByDistanceAndCategory(int page, User user, CategoryEnum category) {
 
         List<Post> posts;
-        if(user.getLongitude()==null||user.getLatitude()==null){
+        if (user.getLongitude() == null || user.getLatitude() == null) {
             posts = getPostsByCategory(page, category);
-        }else{
+        } else {
             posts = getPostsByCategory(page, category, user);
         }
         return posts;
@@ -68,10 +68,10 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
             .selectFrom(post)
             .where(post.store.contains(keyword))
             .orderBy(((post.latitude.subtract(user.getLatitude()))
-                    .multiply((post.latitude.subtract(user.getLatitude())))
-                    .add((post.longitude.subtract(user.getLongitude()))
-                        .multiply((post.longitude.subtract(user.getLongitude())))))
-                    .asc())
+                .multiply((post.latitude.subtract(user.getLatitude())))
+                .add((post.longitude.subtract(user.getLongitude()))
+                    .multiply((post.longitude.subtract(user.getLongitude())))))
+                .asc())
             .offset(offset)
             .limit(pagesize)
             .fetchResults();
@@ -94,10 +94,10 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
     @Override
     public List<Post> getPostsByStatusAndKeywordOrderByDistance(int page, PostStatusEnum statusEnum,
         String keyword, User user) {
-        if(user.getLatitude()==null||user.getLongitude()==null){
+        if (user.getLatitude() == null || user.getLongitude() == null) {
             return getPostsByStatusAndKeyword(page, statusEnum, keyword);
-        }else{
-            return getPostsByStatusAndKeyword(page,statusEnum,keyword,user);
+        } else {
+            return getPostsByStatusAndKeyword(page, statusEnum, keyword, user);
         }
     }
 
@@ -107,6 +107,16 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
             return getPostsByCuisineBeforeLogin(page, cuisine);
         } else {
             return getPostsByCuisineAfterLogin(page, cuisine, user);
+        }
+    }
+
+    @Override
+    public List<Post> getPostsByStatusAndCuisine(int page, PostStatusEnum statusEnum,
+        String cuisine, User user) {
+        if (user.getLongitude() == null || user.getLatitude() == null) {
+            return getPostsByStatusAndCuisineBeforeLogin(page, statusEnum, cuisine);
+        } else {
+            return getPostsByStatusAndCuisineAfterLogin(page, statusEnum, cuisine, user);
         }
     }
 
@@ -183,7 +193,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         return results.getResults();
     }
 
-    private List<Post> getPostsByCategory(int page, CategoryEnum category, User user){
+    private List<Post> getPostsByCategory(int page, CategoryEnum category, User user) {
         QPost post = QPost.post;
         int offset = page * pagesize;
 
@@ -203,7 +213,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         return closestPosts;
     }
 
-    private List<Post> getPostsByCategory(int page, CategoryEnum category){
+    private List<Post> getPostsByCategory(int page, CategoryEnum category) {
         QPost post = QPost.post;
         int offset = page * pagesize;
 
@@ -218,7 +228,8 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         return closestPosts;
     }
 
-    private List<Post> getPostsByStatusAndKeyword(int page, PostStatusEnum statusEnum, String keyword){
+    private List<Post> getPostsByStatusAndKeyword(int page, PostStatusEnum statusEnum,
+        String keyword) {
         QPost post = QPost.post;
         int offset = page * pagesize;
 
@@ -234,7 +245,8 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         return closestPosts;
     }
 
-    private List<Post> getPostsByStatusAndKeyword(int page, PostStatusEnum statusEnum, String keyword, User user){
+    private List<Post> getPostsByStatusAndKeyword(int page, PostStatusEnum statusEnum,
+        String keyword, User user) {
         QPost post = QPost.post;
         int offset = page * pagesize;
 
@@ -254,7 +266,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         return closestPosts;
     }
 
-    private List<Post> getPostsByCuisineBeforeLogin(int page, String cuisine){
+    private List<Post> getPostsByCuisineBeforeLogin(int page, String cuisine) {
         QPost post = QPost.post;
         int offset = page * pagesize;
 
@@ -269,7 +281,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         return closestPosts;
     }
 
-    private List<Post> getPostsByCuisineAfterLogin(int page, String cuisine, User user){
+    private List<Post> getPostsByCuisineAfterLogin(int page, String cuisine, User user) {
         QPost post = QPost.post;
         int offset = page * pagesize;
 
@@ -281,6 +293,44 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                     .add((post.longitude.subtract(user.getLongitude()))
                         .multiply((post.longitude.subtract(user.getLongitude())))))
                     .asc())
+            .offset(offset)
+            .limit(pagesize)
+            .fetchResults();
+
+        return results.getResults();
+    }
+
+    private List<Post> getPostsByStatusAndCuisineBeforeLogin(int page, PostStatusEnum status,
+        String cuisine) {
+        QPost post = QPost.post;
+        int offset = page * pagesize;
+
+        QueryResults<Post> results = jpaQueryFactory
+            .selectFrom(post)
+            .where(post.postStatus.eq(status)
+                .and(post.cuisine.eq(cuisine)))
+            .orderBy(post.deadline.desc())
+            .offset(offset)
+            .limit(pagesize)
+            .fetchResults();
+
+        return results.getResults();
+    }
+
+    private List<Post> getPostsByStatusAndCuisineAfterLogin(int page, PostStatusEnum status,
+        String cuisine, User user) {
+        QPost post = QPost.post;
+        int offset = page * pagesize;
+
+        QueryResults<Post> results = jpaQueryFactory
+            .selectFrom(post)
+            .where(post.postStatus.eq(status)
+                .and(post.cuisine.eq(cuisine)))
+            .orderBy(((post.latitude.subtract(user.getLatitude()))
+                .multiply((post.latitude.subtract(user.getLatitude())))
+                .add((post.longitude.subtract(user.getLongitude()))
+                    .multiply((post.longitude.subtract(user.getLongitude())))))
+                .asc())
             .offset(offset)
             .limit(pagesize)
             .fetchResults();

--- a/src/main/java/com/moayo/moayoeats/backend/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/post/repository/PostRepository.java
@@ -18,6 +18,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findAllByCategoryEquals(Pageable pageable,CategoryEnum category);
 
+    Page<Post> findAllByCuisineEquals(Pageable pageable,String category);
 
     Optional<List<Post>> findPostByStoreContaining(String store);
 

--- a/src/main/java/com/moayo/moayoeats/backend/domain/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/post/service/impl/PostServiceImpl.java
@@ -186,7 +186,6 @@ public class PostServiceImpl implements PostService {
     @Override
     public List<BriefPostResponse> getPostsByCategory(int page, String category, User user) {
         List<Post> posts;
-        CategoryEnum categoryEnum = CategoryEnum.valueOf(category);
 
         if (category.equals(CategoryEnum.ALL.toString())) {
             return getAllPosts(page, user);
@@ -202,7 +201,6 @@ public class PostServiceImpl implements PostService {
     @Override
     public List<BriefPostResponse> getStatusPostsByCategory(int page, String category,
         String status, User user) {
-        CategoryEnum categoryEnum = CategoryEnum.valueOf(category);
         PostStatusEnum statusEnum = PostStatusEnum.valueOf(status);
 
         if (category.equals(CategoryEnum.ALL.toString())) {

--- a/src/main/java/com/moayo/moayoeats/backend/domain/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/post/service/impl/PostServiceImpl.java
@@ -185,10 +185,9 @@ public class PostServiceImpl implements PostService {
     public List<BriefPostResponse> getPostsByCategory(int page, String category, User user) {
         List<Post> posts;
 
-
         if (category.equals(CategoryEnum.ALL.toString())) {
             return getAllPosts(page, user);
-        } else if(checkIfCategoryEnum(category)) {
+        } else if (checkIfCategoryEnum(category)) {
             CategoryEnum categoryEnum = CategoryEnum.valueOf(category);
             posts = postCustomRepository.getPostsByDistanceAndCategory(page, user, categoryEnum);
         } else {
@@ -200,14 +199,20 @@ public class PostServiceImpl implements PostService {
     @Override
     public List<BriefPostResponse> getStatusPostsByCategory(int page, String category,
         String status, User user) {
-        CategoryEnum categoryEnum = CategoryEnum.valueOf(category);
         PostStatusEnum statusEnum = PostStatusEnum.valueOf(status);
 
         if (category.equals(CategoryEnum.ALL.toString())) {
             return getAllStatusPosts(page, statusEnum, user);
-        } else {
+
+        } else if (checkIfCategoryEnum(category)) {
+            CategoryEnum categoryEnum = CategoryEnum.valueOf(category);
             List<Post> posts = postCustomRepository.getPostsByStatusAndCategoryOrderByDistance(page,
                 statusEnum, categoryEnum, user);
+            return postsToBriefResponses(posts);
+
+        } else {
+            List<Post> posts = postCustomRepository.getPostsByStatusAndCuisine(page,
+                statusEnum, category, user);
             return postsToBriefResponses(posts);
         }
     }

--- a/src/main/java/com/moayo/moayoeats/backend/domain/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/post/service/impl/PostServiceImpl.java
@@ -61,18 +61,32 @@ public class PostServiceImpl implements PostService {
         double latitude = Double.valueOf(location[0]);
         double longitude = Double.valueOf(location[1]);
 
-        //Build new post with the post request dto
-        Post post = Post.builder()
-            .latitude(latitude)
-            .longitude(longitude)
-            .store(postReq.store())
-            .deliveryCost(getIntFromString(postReq.deliveryCost()))
-            .minPrice(getIntFromString(postReq.minPrice()))
-            .deadline(deadline)
-            .category(postReq.category())
-            .postStatus(PostStatusEnum.OPEN)
-            .build();
-
+        String category = postReq.category();
+        Post post;
+        if(checkIfCategoryEnum(category)){
+            //Build new post with the post request dto
+            post = Post.builder()
+                .latitude(latitude)
+                .longitude(longitude)
+                .store(postReq.store())
+                .deliveryCost(getIntFromString(postReq.deliveryCost()))
+                .minPrice(getIntFromString(postReq.minPrice()))
+                .deadline(deadline)
+                .category(CategoryEnum.valueOf(category))
+                .postStatus(PostStatusEnum.OPEN)
+                .build();
+        }else{
+            post = Post.builder()
+                .latitude(latitude)
+                .longitude(longitude)
+                .store(postReq.store())
+                .deliveryCost(getIntFromString(postReq.deliveryCost()))
+                .minPrice(getIntFromString(postReq.minPrice()))
+                .deadline(deadline)
+                .cuisine(category)
+                .postStatus(PostStatusEnum.OPEN)
+                .build();
+        }
         //save the post
         postRepository.save(post);
 
@@ -555,6 +569,15 @@ public class PostServiceImpl implements PostService {
     private List<BriefPostResponse> getAllStatusPosts(int page, PostStatusEnum status, User user) {
         List<Post> posts = postCustomRepository.getPostsByStatusOrderByDistance(page, status, user);
         return postsToBriefResponses(posts);
+    }
+
+    private boolean checkIfCategoryEnum(String category){
+        for(CategoryEnum c : CategoryEnum.values()){
+            if (c.name().equals(category)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Scheduled(fixedRate = 60000)//executed every 1 min

--- a/src/main/java/com/moayo/moayoeats/backend/domain/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/moayo/moayoeats/backend/domain/post/service/impl/PostServiceImpl.java
@@ -184,12 +184,15 @@ public class PostServiceImpl implements PostService {
     @Override
     public List<BriefPostResponse> getPostsByCategory(int page, String category, User user) {
         List<Post> posts;
-        CategoryEnum categoryEnum = CategoryEnum.valueOf(category);
+
 
         if (category.equals(CategoryEnum.ALL.toString())) {
             return getAllPosts(page, user);
-        } else {
+        } else if(checkIfCategoryEnum(category)) {
+            CategoryEnum categoryEnum = CategoryEnum.valueOf(category);
             posts = postCustomRepository.getPostsByDistanceAndCategory(page, user, categoryEnum);
+        } else {
+            posts = postCustomRepository.getPostsByCuisine(page, user, category);
         }
         return postsToBriefResponses(posts);
     }

--- a/src/main/resources/templates/domain/post/createpost.html
+++ b/src/main/resources/templates/domain/post/createpost.html
@@ -114,6 +114,11 @@
                onclick="category(this)"
                type="radio">
         <label class="btn btn-outline-secondary" for="lunchbox">도시락</label>
+        <input autocomplete="off" category="CAFE" class="btn-check" id="cafe"
+               name="btnradio"
+               onclick="category(this)"
+               type="radio">
+        <label class="btn btn-outline-secondary" for="cafe">카페</label>
       </div>
     </div>
 

--- a/src/main/resources/templates/domain/post/posts.html
+++ b/src/main/resources/templates/domain/post/posts.html
@@ -93,6 +93,11 @@
              onclick="getByCategory(this)"
              type="radio">
       <label class="btn btn-outline-secondary" for="lunchbox">도시락</label>
+      <input autocomplete="off" category="CAFE" class="btn-check" id="cafe"
+             name="btnradio"
+             onclick="getByCategory(this)"
+             type="radio">
+      <label class="btn btn-outline-secondary" for="cafe">카페</label>
     </div>
     <div id="create-post-btn">
       <button class="btn btn-secondary" onclick="createPost()" type="button">글 작성하기

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -94,6 +94,11 @@
              onclick="getByCategory(this)"
              type="radio">
       <label class="btn btn-outline-secondary" for="lunchbox">도시락</label>
+      <input autocomplete="off" category="CAFE" class="btn-check" id="cafe"
+             name="btnradio"
+             onclick="getByCategory(this)"
+             type="radio">
+      <label class="btn btn-outline-secondary" for="cafe">카페</label>
     </div>
     <div class="input-group mb-3 search-pack">
       <input aria-describedby="button-addon2" aria-label="keyword" class="form-control"


### PR DESCRIPTION
## 개요
- 카페 카테고리 추가하기 
## 작업 사항
 - CategoryEnum에 CAFE Enum 추가하기
 - CategoryValidator에서 CategoryEnum.CAFE 도 걸러주기
 - createpost.html에 CAFE 카테고리 추가
 - index.html에 CAFE 카테고리 추가
 - posts.html에 CAFE 카테고리 추가
## 변경 로직
-  CategoryEnum에 CAFE Enum 추가하기
 - CategoryValidator에서 CategoryEnum.CAFE 도 걸러주기
 - createpost.html에 CAFE 카테고리 추가
 - index.html에 CAFE 카테고리 추가
 - posts.html에 CAFE 카테고리 추가
 -  CategoryEnum에서 CAFE 삭제하기
 - PostRequest의 category type CategoryEnum에서 String으로 변경
 - Post에 String cuisine 추가함
 - CategoryValidator의 CAFE 리터럴로 변경
 - CategoryEnum중의 하나가 아니면 String으로 저장하게 함
 - 로그인 정보 없이 카테고리별 조회시 CategoryEnum중의 하나가 아니면 String으로 조회하게 함
 - PostRepository에 String으로 cuisine 조회하는 메서드 추가
 - 로그인 후 카테고리별 조회시 CategoryEnum중의 하나가 아니면 String으로 조회하게 함
 - PostCustomRepository에 로그인 후 cuisine으로 조회하는 메서드 추가
 - 로그인 후 카테고리별,상태별 조회시 CategoryEnum중의 하나가 아니면 String으로 조회하게 함
 - PostCustomRepository에 로그인 후 상태별로 cuisine으로 조회하는 메서드 추가
## 관련 이슈
- #32
- close #568
